### PR TITLE
Change optionalModules to modules as checkout location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,5 +7,5 @@ dependencies
         {
     external 'org.apache.commons:commons-vfs2:2.0'
 
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:optionalModules:dataintegration", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiCompile")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,7 @@ import org.labkey.gradle.util.BuildUtils;
 apply plugin: 'java'
 apply plugin: 'org.labkey.module'
 
-dependencies
-        {
+dependencies {
     external 'org.apache.commons:commons-vfs2:2.0'
-
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiCompile")
 }
+BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")


### PR DESCRIPTION
Rationale
Consolidate to server/modules as the preferred location for building module code

Related Pull Requests
https://github.com/LabKey/platform/pull/1155

Changes
Update README