### PR TITLE
HtmlString cleanup

### DIFF
--- a/src/org/labkey/immport/ImmPortController.java
+++ b/src/org/labkey/immport/ImmPortController.java
@@ -68,10 +68,10 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.study.ParticipantCategory;
-import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.element.CsrfInput;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.JspView;
@@ -257,7 +257,7 @@ public class ImmPortController extends SpringActionController
             }
             return new HtmlView("<p class='labkey-error'>" + PageFlowUtil.filter(error) + "</p>" +
                 "<form name='populateCube' method='post' onsubmit='Ext4.getBody().mask();true;'>Copy from immport schema to cube dimensions<br>" +
-                "<input type=hidden name='X-LABKEY-CSRF' value='" + CSRFUtil.getExpectedToken(getViewContext()) + "'>" +
+                new CsrfInput(getViewContext()).toString() +
                 "<input type=submit></form>" +
                 "<p></p>" + log);
         }

--- a/src/org/labkey/immport/view/importExpressionMatrix.jsp
+++ b/src/org/labkey/immport/view/importExpressionMatrix.jsp
@@ -8,7 +8,6 @@
 <%@ page import="org.labkey.api.pipeline.PipelineService" %>
 <%@ page import="org.labkey.api.util.Path" %>
 <%@ page import="org.labkey.api.view.BadRequestException" %>
-<%@ page import="static org.labkey.api.reports.RserveScriptEngine.PIPELINE_ROOT" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.immport.ImmPortController" %>
 <%@ page import="java.io.File" %>
@@ -53,7 +52,7 @@
     paths.addAll(xarListing(base));
 
 %>
-    <labkey:form method="POST" name="importExpressionMatrix" action="<%=h(getViewContext().cloneActionURL().deleteParameters())%>">
+    <labkey:form method="POST" name="importExpressionMatrix" action="<%=getViewContext().cloneActionURL().deleteParameters()%>">
 <%
     boolean foundSelected = false;
     %><p>Xar file:&nbsp;<select title="Xar File" required name="xarPath"><%


### PR DESCRIPTION
#### Rationale
No need to encode tag parameters or hand-code CSRF inputs.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1419

#### Changes
* Remove HTML encoding from <labkey:form> tag action parameter
* Use CsrfInput helper class