### PR TITLE
Add module dependencies in build.gradle instead of module.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,13 @@
 import org.labkey.gradle.util.BuildUtils;
 
-apply plugin: 'java'
-apply plugin: 'org.labkey.module'
+plugins {
+   id 'org.labkey.build.module'
+}
 
 dependencies {
     external 'org.apache.commons:commons-vfs2:2.0'
 }
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+

--- a/module.properties
+++ b/module.properties
@@ -6,7 +6,6 @@ License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 Maintainer: ops@immunespace.org
 ModuleClass: org.labkey.immport.ImmPortModule
-ModuleDependencies: Study, DataIntegration
 Name: ImmPort
 Organization: ImmuneSpace Development Team
 OrganizationURL: http://www.immunespace.org


### PR DESCRIPTION
#### Rationale
With gradle plugins version 1.25.0, we are removing support for declaring module dependencies in the `module.properties` file.  These should be declared in the `build.gradle` file now instead.  (If the property is needed for custom build logic, I suggest defining the property in the custom `build.gradle` file.  You can continue to have it in the `module.properties` file but will always get a warning that it is not supported.)

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/119

#### Changes
* Declare module dependencies in the `build.gradle` file.
