### PR TITLE
Schema upgrade fix

### DIFF
--- a/resources/schemas/dbscripts/postgresql/immport-22.000-22.001.sql
+++ b/resources/schemas/dbscripts/postgresql/immport-22.000-22.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE immport.lk_disease ALTER COLUMN name TYPE VARCHAR(100);

--- a/resources/schemas/dbscripts/postgresql/immport-22.001-21.002.sql
+++ b/resources/schemas/dbscripts/postgresql/immport-22.001-21.002.sql
@@ -1,0 +1,5 @@
+-- this is a redo of 21.003-21.004, to handle case where that script did not run (due to PR merge 'problem')
+
+ALTER TABLE immport.arm_or_cohort DROP COLUMN IF EXISTS type;
+ALTER TABLE immport.arm_or_cohort ADD COLUMN IF NOT EXISTS type_reported VARCHAR(100);
+ALTER TABLE immport.arm_or_cohort ADD COLUMN IF NOT EXISTS type_preferred VARCHAR(100);

--- a/src/org/labkey/immport/ImmPortModule.java
+++ b/src/org/labkey/immport/ImmPortModule.java
@@ -70,7 +70,7 @@ public class ImmPortModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.004;
+        return 22.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Fix script mis-numbering problem.  This gets 21.11 where it should be, and can be merged forward.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes

backport immport-22.000-22.001.sql
new script immport-22.001-22.002 which is fix-up/redo script for immport-21.003-21.004
update module version to 22.002