### PR TITLE
Issue 45138: Adjust FolderXarImporterFactory to support unzipped XARs

### DIFF
--- a/src/org/labkey/immport/ImmPortController.java
+++ b/src/org/labkey/immport/ImmPortController.java
@@ -1189,9 +1189,9 @@ public class ImmPortController extends SpringActionController
                 final XarSource source = new AbstractFileXarSource("Expression Matrix import", getContainer(), getUser())
                 {
                     @Override
-                    public File getLogFile() throws IOException
+                    public Path getLogFilePath()
                     {
-                        return ImportPipelineJob.this.getLogFile();
+                        return ImportPipelineJob.this.getLogFilePath();
                     }
                     @Override
                     protected Path getXmlFile()


### PR DESCRIPTION
#### Rationale
Checking in zipped files (like .xar files) makes it hard to edit and view diffs. We can easily handle importing .xar.xml files in folder archives, even if we always export in the compressed form

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3187

#### Changes
* Remove deprecated File method variants in favor of Path
