### PR TITLE
Handle trailing URL question marks

### DIFF
--- a/test/src/org/labkey/test/tests/immport/DataFinderTest.java
+++ b/test/src/org/labkey/test/tests/immport/DataFinderTest.java
@@ -240,9 +240,9 @@ public class DataFinderTest extends BaseWebDriverTest implements PostgresOnlyTes
 
     public void clearSharedStudyContainerFilter() throws IOException, CommandException
     {
-        Connection connection = createDefaultConnection(true);
+        Connection connection = createDefaultConnection();
         new WhoAmICommand().execute(connection, "/"); // Populate session & csrf
-        Command command = new Command("study-shared", "sharedStudyContainerFilter")
+        Command<?> command = new Command<>("study-shared", "sharedStudyContainerFilter")
         {
             @Override
             protected HttpUriRequest createRequest(URI uri)
@@ -1211,7 +1211,7 @@ public class DataFinderTest extends BaseWebDriverTest implements PostgresOnlyTes
         assertTrue("Unexpected error(s) when sending group: [" + String.join(",", errors) + "]", errors.isEmpty());
 
         // If send worked you should be on another page now.
-        if(getURL().getPath().contains("sendParticipantGroup.view?"))
+        if(getURL().getPath().contains("sendParticipantGroup.view"))
         {
             Assert.fail("Did not navigate away from 'study-sendParticipantGroup.view' after clicking send (should have). And no error message was shown on the page (and there should have been).");
         }

--- a/test/src/org/labkey/test/tests/immport/DataFinderTest.java
+++ b/test/src/org/labkey/test/tests/immport/DataFinderTest.java
@@ -73,7 +73,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -624,7 +624,7 @@ public class DataFinderTest extends BaseWebDriverTest implements PostgresOnlyTes
         try (FileSystem fs = FileSystems.newFileSystem(exportedFile.toPath(), (ClassLoader) null)) // 'null' is ambiguous in Java 13+
         {
             // Extract a file
-            List<String> lines = Files.readAllLines(fs.getPath("fcs_analyzed_result.tsv"), Charset.forName("UTF-8"));
+            List<String> lines = Files.readAllLines(fs.getPath("fcs_analyzed_result.tsv"), StandardCharsets.UTF_8);
             Assert.assertEquals(
                     "Expected " + fcs_analyzed_rowCount + " rows and header (dumping first two lines):\n" +
                             StringUtils.join(lines.subList(0, 2), "\n"),
@@ -899,7 +899,7 @@ public class DataFinderTest extends BaseWebDriverTest implements PostgresOnlyTes
         final int SENT_CLICK_DISMISS_LINK = 5;
 
         log("Turn on the experimental feature.");
-        Connection cn = createDefaultConnection(true);
+        Connection cn = createDefaultConnection();
         ExperimentalFeaturesHelper.setExperimentalFeature(cn, "experimental-notificationmenu", true);
 
         goToProjectHome();


### PR DESCRIPTION
#### Rationale
Many tests and helpers are very sensitive to the presence or absence of trailing '?'s on URLs (or "?#" for app URLs). Now that `URLBuilder` checks the `EXPERIMENTAL_NO_QUESTION_MARK_URL` flag when building URLs, numerous tests are getting confused.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1210

#### Changes
* Handle trailing URL question marks
* Clean up some deprecated methods
