### PR TITLE
Auto-generate jars.txt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,23 @@
 import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
    id 'org.labkey.build.module'
 }
 
-dependencies {
-    external 'org.apache.commons:commons-vfs2:2.0'
-}
+BuildUtils.addExternalDependency(
+    project,
+    new ExternalDependency(
+        "org.apache.commons:commons-vfs2:2.0",
+        "Commons Virtual File System",
+        "Apache",
+        "https://commons.apache.org/proper/commons-vfs/",
+        ExternalDependency.APACHE_2_LICENSE_NAME,
+        ExternalDependency.APACHE_2_LICENSE_URL,
+        "Virtual File System support"
+    )
+)
+
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")

--- a/resources/credits/.gitignore
+++ b/resources/credits/.gitignore
@@ -1,1 +1,2 @@
 dependencies.txt
+jars.txt

--- a/resources/credits/jars.txt
+++ b/resources/credits/jars.txt
@@ -1,4 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-commons-vfs2-2.0.jar|ImmPort|2.0|{link:Apache Commons VFS|https://commons.apache.org/proper/commons-vfs/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|matthewb|Virtual File System support
-{table}


### PR DESCRIPTION
#### Rationale
Our build can now auto-generate the `jars.txt` credits file, simplifying maintenance